### PR TITLE
Добавлены исключения при отсутствии файлов сертификата и ключа.

### DIFF
--- a/src/exceptions/SignFailException.php
+++ b/src/exceptions/SignFailException.php
@@ -7,11 +7,17 @@ class SignFailException extends BaseException
     const CODE_CANT_READ_CERT = 500;
     const CODE_CANT_READ_PRIVATE_KEY = 501;
     const CODE_SIGN_FAIL = 502;
+    const CODE_NO_SUCH_CERT_FILE = 504;
+    const CODE_NO_SUCH_KEY_FILE = 505;
+    const CODE_NO_TEMP_DIRECTORY = 506;
 
     protected static $codeLabels = [
         self::CODE_CANT_READ_CERT => 'Can\'t read a certificate',
         self::CODE_CANT_READ_PRIVATE_KEY => 'Can\'t read a private key',
         self::CODE_SIGN_FAIL => 'Sign fail',
+        self::CODE_NO_SUCH_CERT_FILE => 'There is no such certificate',
+        self::CODE_NO_SUCH_KEY_FILE => 'There is no such key file',
+        self::CODE_NO_TEMP_DIRECTORY => 'We need temporary directory, but we don\'t have one',
     ];
 
 

--- a/tests/unit/OpenIdTest.php
+++ b/tests/unit/OpenIdTest.php
@@ -230,7 +230,6 @@ class OpenIdTest extends \Codeception\TestCase\Test
 
     public function testGetUrl()
     {
-
         $url = $this->openId->getUrl();
         $this->assertNotFalse(filter_var($url, FILTER_VALIDATE_URL));
 


### PR DESCRIPTION
Так как файлы читаются с помощью `file_get_contents`, то при их отсутствии (например, если в конфигурации указан на правильный путь до файла), мы получаем `warning`, который по идее нам совсем не нужен. По этому мы добавили ещё несколько Exceptions, которые выкидываются если:

* если у нас нет файла серификата
* если у нас нет файла ключа
* если у нас нет tmp папки

Для «красоты», проверка на эти исключения была вынесена в отдельный метод.

Так же теперь в лог пишутся ошибки ssl возинкающие при генерации сертификата.