### PR TITLE
Engine gost

### DIFF
--- a/src/Esia/Signer/CliSignerPKCS7.php
+++ b/src/Esia/Signer/CliSignerPKCS7.php
@@ -26,7 +26,7 @@ class CliSignerPKCS7 extends AbstractSignerPKCS7 implements SignerInterface
 
         $this->run(
             'openssl ' .
-            'smime -sign -binary -outform DER -noattr ' .
+            'smime -engine gost -sign -binary -outform DER -noattr ' .
             '-signer ' . escapeshellarg($this->certPath) . ' ' .
             '-inkey ' . escapeshellarg($this->privateKeyPath) . ' ' .
             '-passin ' . escapeshellarg('pass:' . $this->privateKeyPassword) . ' ' .

--- a/src/Esia/Signer/CliSignerPKCS7.php
+++ b/src/Esia/Signer/CliSignerPKCS7.php
@@ -26,7 +26,7 @@ class CliSignerPKCS7 extends AbstractSignerPKCS7 implements SignerInterface
 
         $this->run(
             'openssl ' .
-            'smime -engine gost -sign -binary -outform DER -noattr ' .
+            'smime -sign -binary -outform DER -noattr ' .
             '-signer ' . escapeshellarg($this->certPath) . ' ' .
             '-inkey ' . escapeshellarg($this->privateKeyPath) . ' ' .
             '-passin ' . escapeshellarg('pass:' . $this->privateKeyPassword) . ' ' .

--- a/tests/unit/OpenIdTest.php
+++ b/tests/unit/OpenIdTest.php
@@ -180,6 +180,31 @@ class OpenIdTest extends Unit
     }
 
     /**
+     * @throws \Esia\Exceptions\InvalidConfigurationException
+     */
+    public function testBuildLogoutUrl(): void
+    {
+        $config = $this->openId->getConfig();
+
+        $url = $config->getLogoutUrl() . '?client_id=' . $config->getClientId();
+        $logoutUrl = $this->openId->buildLogoutUrl();
+        $this->assertSame($url, $logoutUrl);
+    }
+
+    /**
+     * @throws \Esia\Exceptions\InvalidConfigurationException
+     */
+    public function testBuildLogoutUrlWithRedirect(): void
+    {
+        $config = $this->openId->getConfig();
+        
+        $redirectUrl = 'test.example.com';
+        $url = $config->getLogoutUrl() . '?client_id=' . $config->getClientId() . '&redirect_url=' . $redirectUrl;
+        $logoutUrl = $this->openId->buildLogoutUrl($redirectUrl);
+        $this->assertSame($url, $logoutUrl);
+    }
+
+    /**
      * Client with prepared responses
      *
      * @param array $responses

--- a/tests/unit/OpenIdTest.php
+++ b/tests/unit/OpenIdTest.php
@@ -205,6 +205,31 @@ class OpenIdTest extends Unit
     }
 
     /**
+     * @throws \Esia\Exceptions\InvalidConfigurationException
+     */
+    public function testBuildLogoutUrl(): void
+    {
+        $config = $this->openId->getConfig();
+
+        $url = $config->getLogoutUrl() . '?client_id=' . $config->getClientId();
+        $logoutUrl = $this->openId->buildLogoutUrl();
+        $this->assertSame($url, $logoutUrl);
+    }
+
+    /**
+     * @throws \Esia\Exceptions\InvalidConfigurationException
+     */
+    public function testBuildLogoutUrlWithRedirect(): void
+    {
+        $config = $this->openId->getConfig();
+        
+        $redirectUrl = 'test.example.com';
+        $url = $config->getLogoutUrl() . '?client_id=' . $config->getClientId() . '&redirect_url=' . $redirectUrl;
+        $logoutUrl = $this->openId->buildLogoutUrl($redirectUrl);
+        $this->assertSame($url, $logoutUrl);
+    }
+
+    /**
      * Client with prepared responses
      *
      * @param array $responses


### PR DESCRIPTION
Предлагаю добавить "-engine gost" при вызове CliSigner чтобы форсировать использование gost, когда он установлен через пакет без дополнительной настройки.