### PR TITLE
Extend constructor for signer and logger

### DIFF
--- a/src/Esia/OpenId.php
+++ b/src/Esia/OpenId.php
@@ -19,6 +19,7 @@ use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
 
@@ -48,12 +49,16 @@ class OpenId
      */
     private $config;
 
-    public function __construct(Config $config, ClientInterface $client = null)
-    {
+    public function __construct(
+        Config $config,
+        ClientInterface $client = null,
+        SignerInterface $signer = null,
+        LoggerInterface $logger = null
+    ) {
         $this->config = $config;
         $this->client = $client ?? new GuzzleHttpClient(new Client());
-        $this->logger = new NullLogger();
-        $this->signer = new SignerPKCS7(
+        $this->logger = $logger ?? new NullLogger();
+        $this->signer = $signer ?? new SignerPKCS7(
             $config->getCertPath(),
             $config->getPrivateKeyPath(),
             $config->getPrivateKeyPassword(),


### PR DESCRIPTION
Я подумал, можно расширить конструктор двумя необязательными аргументами для управления инициацией логгера и подписывателя. Поскольку иногда возникает проблема (#31) с подписью через SignerPKCS7, приходится использовать CliSignerPKCS7. Сейчас это можно сделать только через setSigner(), но при этом в конструкторе происходит создание ненужного объекта. Логгер (#30) тоже можно добавить, чтобы, к примеру, можно было настраивать через контейнер зависимостей.

Обратная совместимость не нарушается.

Из минусов только раздувание списка параметров.