### PR TITLE
Передача стейта

### DIFF
--- a/src/Esia/OpenId.php
+++ b/src/Esia/OpenId.php
@@ -87,10 +87,10 @@ class OpenId
      * @return string|false
      * @throws SignFailException
      */
-    public function buildUrl()
+    public function buildUrl(string $state = null)
     {
         $timestamp = $this->getTimeStamp();
-        $state = $this->buildState();
+        $state = $state ?? $this->buildState();
         $message = $this->config->getScopeString()
             . $timestamp
             . $this->config->getClientId()

--- a/tests/unit/OpenIdTest.php
+++ b/tests/unit/OpenIdTest.php
@@ -156,6 +156,13 @@ class OpenIdTest extends Unit
         self::assertSame([['phone' => '555 555 555'], ['email' => 'test@gmail.com']], $info);
     }
 
+    public function testBuildUrl(): void
+    {
+        $state = '47e1f1e9-8b56-4666-ac02-d1408408e5f2';
+        $url = $this->openId->buildUrl($state);
+        self::assertStringContainsString($state, $url);
+    }
+
     /**
      * @throws InvalidConfigurationException
      */


### PR DESCRIPTION
Стейт нужен, чтобы сопоставить откуда была вызвана аутентификация. Например, пользователь может открыть два окна входа одновременно, и нужно понимать куда его перенаправить после возвращения из ЕСИА.
