### PR TITLE
Add GOST signing round-trip test and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,26 @@ jobs:
 
       - name: PHPStan
         run: vendor/bin/phpstan analyse --no-progress
+
+  gost-roundtrip:
+    runs-on: ubuntu-24.04
+    name: GOST signing round-trip
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - name: Setup GOST OpenSSL engine
+        run: |
+          sudo apt-get install -y libengine-gost-openssl1.1
+          sudo cp tests/openssl.cnf /usr/lib/ssl/openssl.cnf
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: openssl
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction
+
+      - name: Sign and verify a GOST-2012 signature
+        run: vendor/bin/codecept run -g gost

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -1,0 +1,46 @@
+# Test fixtures
+
+## RSA fixtures (`server.crt`, `server.key`, `server.csr`)
+
+Used by `SignerPKCS7Test` and `OpenIdTest`. Standard self-signed RSA material:
+
+```sh
+openssl req -x509 -newkey rsa:2048 -nodes \
+  -keyout server.key -out server.crt -days 3650 \
+  -subj '/C=RU/CN=Tester'
+# the private key is then (re)encrypted with the password "test"
+openssl rsa -in server.key -out server.key -aes256 -passout pass:test
+```
+
+## GOST fixtures (`server-gost.crt`, `server-gost.key`)
+
+Used by `OpenIdCliOpensslTest` and `CliSignerRoundTripTest` to exercise the
+`CliSignerPKCS7` (GOST) signing path. They are a **self-signed GOST R 34.10-2001**
+certificate/key pair (`id-GostR3410-2001-CryptoPro-A-ParamSet`, `CN=Tester GOST 2001`),
+valid until 2068, with the private key protected by the password `test`.
+
+They require an OpenSSL build with the GOST engine (e.g. `libengine-gost-openssl1.1`
+plus `tests/openssl.cnf`, as configured in `.github/workflows/ci.yml`). To regenerate
+an equivalent pair with a GOST-enabled OpenSSL:
+
+```sh
+# self-signed GOST-2001 certificate + key, key password "test"
+openssl req -x509 -engine gost \
+  -newkey gost2001 -pkeyopt paramset:A \
+  -passout pass:test \
+  -keyout server-gost.key -out server-gost.crt \
+  -days 18250 -subj '/C=RU/CN=Tester GOST 2001'
+```
+
+`CliSignerRoundTripTest` signs a known message with `CliSignerPKCS7` and then verifies
+the resulting detached PKCS#7 signature with:
+
+```sh
+openssl smime -engine gost -verify -binary -inform DER -noverify \
+  -in <signature.der> -content <message>
+```
+
+## `non_readable_file`
+
+An intentionally empty file whose mode is set to `000` in CI
+(`chmod 000 tests/_data/non_readable_file`) to test unreadable-file error paths.

--- a/tests/unit/Signer/CliSignerRoundTripTest.php
+++ b/tests/unit/Signer/CliSignerRoundTripTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\unit\Signer;
+
+use Codeception\Test\Unit;
+use Esia\Signer\CliSignerPKCS7;
+
+/**
+ * Signs a known message with the production CLI signer and verifies that the
+ * produced detached GOST PKCS#7 signature round-trips through `openssl smime -verify`.
+ *
+ * Requires the GOST OpenSSL engine (see .github/workflows/ci.yml and tests/openssl.cnf).
+ *
+ * @group gost
+ * @coversNothing
+ */
+class CliSignerRoundTripTest extends Unit
+{
+    private function signer(): CliSignerPKCS7
+    {
+        return new CliSignerPKCS7(
+            codecept_data_dir('server-gost.crt'),
+            codecept_data_dir('server-gost.key'),
+            'test',
+            codecept_log_dir()
+        );
+    }
+
+    /**
+     * Verify a detached GOST PKCS#7 signature via openssl.
+     *
+     * @return array{0:int,1:string} exit code and combined output
+     */
+    private function verify(string $derPath, string $messagePath): array
+    {
+        $command = 'openssl smime -engine gost -verify -binary -inform DER -noverify '
+            . '-in ' . escapeshellarg($derPath) . ' '
+            . '-content ' . escapeshellarg($messagePath) . ' 2>&1';
+
+        exec($command, $output, $code);
+
+        return [$code, implode("\n", $output)];
+    }
+
+    public function testSignatureRoundTrips(): void
+    {
+        $message = 'esia-round-trip-' . bin2hex(random_bytes(8));
+        $signature = $this->signer()->sign($message);
+        self::assertNotEmpty($signature);
+
+        // Reverse CliSignerPKCS7::urlSafe() back to standard base64, then to DER.
+        $der = base64_decode(strtr($signature, '-_', '+/'), true);
+        self::assertNotFalse($der, 'Signature is not valid base64');
+
+        $derPath = codecept_log_dir('roundtrip.der');
+        $messagePath = codecept_log_dir('roundtrip.msg');
+        file_put_contents($derPath, $der);
+        file_put_contents($messagePath, $message);
+
+        [$code, $output] = $this->verify($derPath, $messagePath);
+
+        unlink($derPath);
+        unlink($messagePath);
+
+        self::assertSame(0, $code, 'openssl could not verify the signature: ' . $output);
+    }
+
+    public function testVerificationFailsForTamperedMessage(): void
+    {
+        $message = 'esia-round-trip-' . bin2hex(random_bytes(8));
+        $signature = $this->signer()->sign($message);
+
+        $der = base64_decode(strtr($signature, '-_', '+/'), true);
+        self::assertNotFalse($der);
+
+        $derPath = codecept_log_dir('roundtrip-tampered.der');
+        $messagePath = codecept_log_dir('roundtrip-tampered.msg');
+        file_put_contents($derPath, $der);
+        file_put_contents($messagePath, $message . '-tampered');
+
+        [$code] = $this->verify($derPath, $messagePath);
+
+        unlink($derPath);
+        unlink($messagePath);
+
+        self::assertNotSame(0, $code, 'Verification unexpectedly succeeded for a tampered message');
+    }
+}


### PR DESCRIPTION
Closes #71.

## What
Adds an offline test proving the library's GOST signing path works without ESIA infrastructure.

- **`tests/unit/Signer/CliSignerRoundTripTest.php`** — signs a known message with the production `CliSignerPKCS7` and verifies the resulting **detached** GOST PKCS#7 signature round-trips via `openssl smime -engine gost -verify`. Includes a negative test asserting verification fails for a tampered message.
- **`.github/workflows/ci.yml`** — new dedicated `gost-roundtrip` job (sets up `libengine-gost-openssl1.1` + `tests/openssl.cnf`, then runs `codecept run -g gost`). The matrix `test` job also runs the new `@group gost` test.
- **`tests/_data/README.md`** — documents how the RSA and GOST test cert/key fixtures were generated (acceptance criterion). The GOST pair is a self-signed GOST R 34.10-2001 cert, param set CryptoPro-A, key password `test`.

## Verification
The sign→verify round-trip was confirmed experimentally with a GOST-enabled OpenSSL (detached PKCS#7 verified with `-content`; opaque verify does not apply). Full test execution runs in CI, which has a GOST-capable environment.