### PR TITLE
Validate JWT (signature + claims) received from ESIA

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,42 @@ $documentInfo = $esia->getDocInfo();
 
 `tmpPath` - путь до дериктории где будет проходить подпись (должна быть доступна для записи).
 
-# Токен и oid
+`esiaCertPath` - по умолчанию: пусто. Путь до сертификата подписи ЕСИА (для продуктивной среды — GOST-2012). Если задан, полученный JWT автоматически проверяется: подпись, `exp`/`nbf`/`iat`, `iss` и аудитория (`aud`/`client_id`). Если не задан, проверка пропускается (обратная совместимость).
+
+`esiaTokenIssuer` - по умолчанию: пусто. Ожидаемое значение claim `iss` в токене. Если не задано, `iss` не проверяется.
+
+`tokenLeeway` - по умолчанию: `60`. Допустимое отклонение (в секундах) при проверке временных claim'ов (`exp`, `nbf`, `iat`) для компенсации рассинхронизации часов.
+
+## Проверка JWT (подпись и claim'ы)
+
+По умолчанию библиотека не проверяет подпись полученного от ЕСИА токена — это
+сохраняет обратную совместимость. Чтобы включить проверку, укажите путь до
+сертификата подписи ЕСИА через `esiaCertPath` (и, при необходимости,
+`esiaTokenIssuer`):
+
+```php
+$config = new \Esia\Config([
+    // ... остальные параметры
+    'esiaCertPath'    => '/path/to/esia-signing-cert.pem',
+    'esiaTokenIssuer' => 'http://esia.gosuslugi.ru/',
+]);
+$esia = new \Esia\OpenId($config);
+
+// getToken выбросит наследника InvalidTokenException при некорректном токене:
+// SignatureInvalidException — неверная подпись,
+// TokenExpiredException     — истёк срок (exp) или ещё не действителен (nbf),
+// InvalidClaimException     — неверный iss / аудитория (aud/client_id).
+$token = $esia->getToken($_GET['code']);
+```
+
+Проверка сделана подключаемой (pluggable): вы можете передать собственную
+реализацию `\Esia\Token\TokenValidatorInterface` (например, с проверкой
+GOST-подписи через CryptoPro) через `\Esia\OpenId::setTokenValidator()`.
+Стандартная реализация `\Esia\Token\JwtValidator` проверяет подпись через
+`\Esia\Token\OpenSslSignatureVerifier` (RSA из коробки; алгоритмы GOST-2012 —
+при наличии GOST-движка в OpenSSL).
+
+
 
 Токен - jwt токен которые вы получаете от ЕСИА для дальнейшего взаимодействия
 

--- a/src/Esia/Config.php
+++ b/src/Esia/Config.php
@@ -22,6 +22,23 @@ class Config
     private string $clientCertificateHash = '';
 
     /**
+     * Path to the ESIA signing certificate used to validate the JWT access
+     * token. When set, the token is validated automatically after it is
+     * fetched. When null, token validation is skipped (backward compatible).
+     */
+    private ?string $esiaCertPath = null;
+
+    /**
+     * Expected `iss` claim of the access token. Null skips the issuer check.
+     */
+    private ?string $esiaTokenIssuer = null;
+
+    /**
+     * Allowed clock skew (in seconds) when validating time-based claims.
+     */
+    private int $tokenLeeway = 60;
+
+    /**
      * @var string[]
      */
     private array $scope = [
@@ -77,6 +94,9 @@ class Config
         $this->logoutUrlPath = $config['logoutUrlPath'] ?? $this->logoutUrlPath;
         $this->privateKeyPassword = $config['privateKeyPassword'] ?? $this->privateKeyPassword;
         $this->clientCertificateHash = $config['clientCertificateHash'] ?? $this->clientCertificateHash;
+        $this->esiaCertPath = $config['esiaCertPath'] ?? $this->esiaCertPath;
+        $this->esiaTokenIssuer = $config['esiaTokenIssuer'] ?? $this->esiaTokenIssuer;
+        $this->tokenLeeway = (int) ($config['tokenLeeway'] ?? $this->tokenLeeway);
         $this->oid = $config['oid'] ?? $this->oid;
         $scope = $config['scope'] ?? $this->scope;
         if (!is_array($scope)) {
@@ -113,6 +133,21 @@ class Config
     public function getClientCertificateHash(): string
     {
         return $this->clientCertificateHash;
+    }
+
+    public function getEsiaCertPath(): ?string
+    {
+        return $this->esiaCertPath;
+    }
+
+    public function getEsiaTokenIssuer(): ?string
+    {
+        return $this->esiaTokenIssuer;
+    }
+
+    public function getTokenLeeway(): int
+    {
+        return $this->tokenLeeway;
     }
 
     public function getCertPath(): string

--- a/src/Esia/Exceptions/InvalidClaimException.php
+++ b/src/Esia/Exceptions/InvalidClaimException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Esia\Exceptions;
+
+/**
+ * Thrown when a standard claim (iss, aud/client_id, iat) does not match
+ * the expected value.
+ */
+class InvalidClaimException extends InvalidTokenException
+{
+}

--- a/src/Esia/Exceptions/InvalidTokenException.php
+++ b/src/Esia/Exceptions/InvalidTokenException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Esia\Exceptions;
+
+/**
+ * Base exception for any failure while validating a JWT received from ESIA.
+ */
+class InvalidTokenException extends AbstractEsiaException
+{
+}

--- a/src/Esia/Exceptions/SignatureInvalidException.php
+++ b/src/Esia/Exceptions/SignatureInvalidException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Esia\Exceptions;
+
+/**
+ * Thrown when the JWT signature cannot be verified against the ESIA certificate.
+ */
+class SignatureInvalidException extends InvalidTokenException
+{
+}

--- a/src/Esia/Exceptions/TokenExpiredException.php
+++ b/src/Esia/Exceptions/TokenExpiredException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Esia\Exceptions;
+
+/**
+ * Thrown when the JWT is expired (exp) or not yet valid (nbf).
+ */
+class TokenExpiredException extends InvalidTokenException
+{
+}

--- a/src/Esia/OpenId.php
+++ b/src/Esia/OpenId.php
@@ -6,6 +6,7 @@ namespace Esia;
 
 use Esia\Exceptions\AbstractEsiaException;
 use Esia\Exceptions\ForbiddenException;
+use Esia\Exceptions\InvalidClaimException;
 use Esia\Exceptions\RequestFailException;
 use Esia\Signer\Exceptions\CannotGenerateRandomIntException;
 use Esia\Signer\Exceptions\SignFailException;
@@ -222,15 +223,22 @@ class OpenId
         $this->logger->debug('Payload: ', $payload);
 
         $token = $payload['access_token'];
-        $this->config->setToken($token);
 
         # get object id from token
         $chunks = explode('.', $token);
         if ($this->tokenValidator !== null) {
             $claims = $this->tokenValidator->validate($token);
         } else {
-            $claims = json_decode($this->base64UrlSafeDecode($chunks[1]), true);
+            $claims = json_decode($this->base64UrlSafeDecode($chunks[1] ?? ''), true);
         }
+
+        if (!is_array($claims) || !isset($claims['urn:esia:sbj_id'])) {
+            throw new InvalidClaimException('The token does not contain the subject id (urn:esia:sbj_id)');
+        }
+
+        // Only accept the token into client state once it has been validated
+        // and the subject id has been extracted.
+        $this->config->setToken($token);
         $this->config->setOid((string) $claims['urn:esia:sbj_id']);
 
         return $token;

--- a/src/Esia/OpenId.php
+++ b/src/Esia/OpenId.php
@@ -11,6 +11,9 @@ use Esia\Signer\Exceptions\CannotGenerateRandomIntException;
 use Esia\Signer\Exceptions\SignFailException;
 use Esia\Signer\SignerInterface;
 use Esia\Signer\SignerPKCS7;
+use Esia\Token\JwtValidator;
+use Esia\Token\OpenSslSignatureVerifier;
+use Esia\Token\TokenValidatorInterface;
 use Exception;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Discovery\Psr18ClientDiscovery;
@@ -32,6 +35,12 @@ class OpenId
     use LoggerAwareTrait;
 
     private SignerInterface $signer;
+
+    /**
+     * Validator for the JWT access token. Null means validation is disabled
+     * (backward compatible default).
+     */
+    private ?TokenValidatorInterface $tokenValidator = null;
 
     /**
      * Http Client
@@ -64,6 +73,28 @@ class OpenId
             $config->getPrivateKeyPassword(),
             $config->getTmpPath()
         );
+
+        $esiaCertPath = $config->getEsiaCertPath();
+        if ($esiaCertPath !== null && $esiaCertPath !== '') {
+            $this->tokenValidator = new JwtValidator(
+                OpenSslSignatureVerifier::fromFile($esiaCertPath),
+                $config->getEsiaTokenIssuer(),
+                $config->getClientId(),
+                $config->getTokenLeeway()
+            );
+        }
+    }
+
+    /**
+     * Replace the default JWT token validator or enable validation.
+     *
+     * When a validator is set, {@see OpenId::getToken()} verifies the token
+     * signature and claims before accepting it. This makes validation
+     * pluggable so integrators can supply the current ESIA certificate.
+     */
+    public function setTokenValidator(?TokenValidatorInterface $tokenValidator): void
+    {
+        $this->tokenValidator = $tokenValidator;
     }
 
     /**
@@ -195,8 +226,12 @@ class OpenId
 
         # get object id from token
         $chunks = explode('.', $token);
-        $payload = json_decode($this->base64UrlSafeDecode($chunks[1]), true);
-        $this->config->setOid((string) $payload['urn:esia:sbj_id']);
+        if ($this->tokenValidator !== null) {
+            $claims = $this->tokenValidator->validate($token);
+        } else {
+            $claims = json_decode($this->base64UrlSafeDecode($chunks[1]), true);
+        }
+        $this->config->setOid((string) $claims['urn:esia:sbj_id']);
 
         return $token;
     }

--- a/src/Esia/Token/JwtValidator.php
+++ b/src/Esia/Token/JwtValidator.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Esia\Token;
+
+use Esia\Exceptions\InvalidClaimException;
+use Esia\Exceptions\SignatureInvalidException;
+use Esia\Exceptions\TokenExpiredException;
+
+/**
+ * Default JWT validator for tokens issued by ESIA.
+ *
+ * It verifies the token signature (via a {@see SignatureVerifierInterface})
+ * and validates the standard claims: `exp`, `nbf`, `iat` (with a configurable
+ * leeway for clock skew), the issuer (`iss`) and the audience
+ * (`aud`/`client_id`).
+ */
+class JwtValidator implements TokenValidatorInterface
+{
+    private SignatureVerifierInterface $signatureVerifier;
+
+    private ?string $expectedIssuer;
+
+    private ?string $expectedAudience;
+
+    private int $leeway;
+
+    /**
+     * @param SignatureVerifierInterface $signatureVerifier Verifier bound to the ESIA certificate.
+     * @param string|null                $expectedIssuer    Expected `iss` claim, or null to skip.
+     * @param string|null                $expectedAudience  Expected audience/`client_id`, or null to skip.
+     * @param int                        $leeway            Allowed clock skew in seconds for time claims.
+     */
+    public function __construct(
+        SignatureVerifierInterface $signatureVerifier,
+        ?string $expectedIssuer = null,
+        ?string $expectedAudience = null,
+        int $leeway = 60
+    ) {
+        $this->signatureVerifier = $signatureVerifier;
+        $this->expectedIssuer = $expectedIssuer;
+        $this->expectedAudience = $expectedAudience;
+        $this->leeway = $leeway;
+    }
+
+    public function validate(string $token): array
+    {
+        $segments = explode('.', $token);
+        if (count($segments) !== 3) {
+            throw new InvalidClaimException('The token is not a well-formed JWT');
+        }
+
+        [$encodedHeader, $encodedPayload, $encodedSignature] = $segments;
+
+        $header = $this->decodeSegment($encodedHeader, 'header');
+        $payload = $this->decodeSegment($encodedPayload, 'payload');
+        $signature = self::base64UrlDecode($encodedSignature);
+
+        if ($signature === '') {
+            throw new SignatureInvalidException('The token has no signature');
+        }
+
+        $algorithm = $header['alg'] ?? '';
+        if (!is_string($algorithm) || $algorithm === '' || strcasecmp($algorithm, 'none') === 0) {
+            throw new SignatureInvalidException('The token does not specify a signing algorithm');
+        }
+
+        $this->signatureVerifier->verify($encodedHeader . '.' . $encodedPayload, $signature, $algorithm);
+
+        $this->validateClaims($payload);
+
+        return $payload;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @throws TokenExpiredException
+     * @throws InvalidClaimException
+     */
+    private function validateClaims(array $payload): void
+    {
+        $now = time();
+
+        if (isset($payload['exp']) && $now >= ((int) $payload['exp'] + $this->leeway)) {
+            throw new TokenExpiredException('The token has expired');
+        }
+
+        if (isset($payload['nbf']) && $now < ((int) $payload['nbf'] - $this->leeway)) {
+            throw new TokenExpiredException('The token is not valid yet (nbf)');
+        }
+
+        if (isset($payload['iat']) && ((int) $payload['iat'] - $this->leeway) > $now) {
+            throw new InvalidClaimException('The token was issued in the future (iat)');
+        }
+
+        if ($this->expectedIssuer !== null) {
+            $issuer = $payload['iss'] ?? null;
+            if ($issuer !== $this->expectedIssuer) {
+                throw new InvalidClaimException(
+                    sprintf('Unexpected token issuer: %s', is_string($issuer) ? $issuer : 'none')
+                );
+            }
+        }
+
+        if ($this->expectedAudience !== null) {
+            $this->assertAudience($payload);
+        }
+    }
+
+    /**
+     * ESIA tokens may carry the audience either in the standard `aud` claim or
+     * in a `client_id` claim. Accept both.
+     *
+     * @param array<string, mixed> $payload
+     *
+     * @throws InvalidClaimException
+     */
+    private function assertAudience(array $payload): void
+    {
+        $audience = $payload['aud'] ?? $payload['client_id'] ?? null;
+
+        $audiences = is_array($audience) ? $audience : [$audience];
+        foreach ($audiences as $value) {
+            if (is_string($value) && $value === $this->expectedAudience) {
+                return;
+            }
+        }
+
+        throw new InvalidClaimException('The token audience does not match the client id');
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @throws InvalidClaimException
+     */
+    private function decodeSegment(string $segment, string $name): array
+    {
+        $decoded = json_decode(self::base64UrlDecode($segment), true);
+        if (!is_array($decoded)) {
+            throw new InvalidClaimException(sprintf('Cannot decode the JWT %s', $name));
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+
+    private static function base64UrlDecode(string $string): string
+    {
+        $base64 = strtr($string, '-_', '+/');
+        $padding = strlen($base64) % 4;
+        if ($padding > 0) {
+            $base64 .= str_repeat('=', 4 - $padding);
+        }
+
+        $decoded = base64_decode($base64, true);
+
+        return $decoded === false ? '' : $decoded;
+    }
+}

--- a/src/Esia/Token/JwtValidator.php
+++ b/src/Esia/Token/JwtValidator.php
@@ -83,15 +83,18 @@ class JwtValidator implements TokenValidatorInterface
     {
         $now = time();
 
-        if (isset($payload['exp']) && $now >= ((int) $payload['exp'] + $this->leeway)) {
+        $exp = $this->numericClaim($payload, 'exp');
+        if ($exp !== null && $now >= ($exp + $this->leeway)) {
             throw new TokenExpiredException('The token has expired');
         }
 
-        if (isset($payload['nbf']) && $now < ((int) $payload['nbf'] - $this->leeway)) {
+        $nbf = $this->numericClaim($payload, 'nbf');
+        if ($nbf !== null && $now < ($nbf - $this->leeway)) {
             throw new TokenExpiredException('The token is not valid yet (nbf)');
         }
 
-        if (isset($payload['iat']) && ((int) $payload['iat'] - $this->leeway) > $now) {
+        $iat = $this->numericClaim($payload, 'iat');
+        if ($iat !== null && ($iat - $this->leeway) > $now) {
             throw new InvalidClaimException('The token was issued in the future (iat)');
         }
 
@@ -107,6 +110,29 @@ class JwtValidator implements TokenValidatorInterface
         if ($this->expectedAudience !== null) {
             $this->assertAudience($payload);
         }
+    }
+
+    /**
+     * Read a JWT NumericDate claim, rejecting non-numeric values.
+     *
+     * @param array<string, mixed> $payload
+     *
+     * @throws InvalidClaimException
+     */
+    private function numericClaim(array $payload, string $name): ?int
+    {
+        if (!isset($payload[$name])) {
+            return null;
+        }
+
+        $value = $payload[$name];
+        if (!is_int($value) && !is_float($value) && !(is_string($value) && is_numeric($value))) {
+            throw new InvalidClaimException(
+                sprintf('The "%s" claim is not a valid numeric date', $name)
+            );
+        }
+
+        return (int) $value;
     }
 
     /**

--- a/src/Esia/Token/OpenSslSignatureVerifier.php
+++ b/src/Esia/Token/OpenSslSignatureVerifier.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Esia\Token;
+
+use Esia\Exceptions\SignatureInvalidException;
+use OpenSSLAsymmetricKey;
+
+/**
+ * OpenSSL based JWT signature verifier.
+ *
+ * Supports RSA (RS256/RS384/RS512) out of the box and the GOST 34.10-2012
+ * algorithms used by ESIA in production when the OpenSSL build provides the
+ * GOST engine (e.g. via `libengine-gost-openssl1.1`).
+ */
+class OpenSslSignatureVerifier implements SignatureVerifierInterface
+{
+    /**
+     * Map of JWT "alg" values to OpenSSL digest algorithms.
+     *
+     * RSA algorithms use the OPENSSL_ALGO_* integer constants; GOST algorithms
+     * use the digest method name resolved by the loaded engine.
+     *
+     * @var array<string, int|string>
+     */
+    private const ALGORITHMS = [
+        'RS256' => OPENSSL_ALGO_SHA256,
+        'RS384' => OPENSSL_ALGO_SHA384,
+        'RS512' => OPENSSL_ALGO_SHA512,
+        'GOST3410_2012_256' => 'md_gost12_256',
+        'GOST3410_2012_512' => 'md_gost12_512',
+    ];
+
+    private string $certificate;
+
+    /**
+     * @param string $certificate The ESIA signing certificate or public key in
+     *                            PEM format (the certificate contents, not a path).
+     */
+    public function __construct(string $certificate)
+    {
+        $this->certificate = $certificate;
+    }
+
+    /**
+     * Build a verifier from a certificate file path.
+     *
+     * @throws SignatureInvalidException When the file cannot be read.
+     */
+    public static function fromFile(string $path): self
+    {
+        $contents = @file_get_contents($path);
+        if ($contents === false) {
+            throw new SignatureInvalidException(
+                sprintf('Cannot read the ESIA signing certificate: %s', $path)
+            );
+        }
+
+        return new self($contents);
+    }
+
+    public function verify(string $signingInput, string $signature, string $algorithm): void
+    {
+        if (!isset(self::ALGORITHMS[$algorithm])) {
+            throw new SignatureInvalidException(
+                sprintf('Unsupported JWT signature algorithm: %s', $algorithm)
+            );
+        }
+
+        $publicKey = $this->resolvePublicKey();
+
+        $result = openssl_verify(
+            $signingInput,
+            $signature,
+            $publicKey,
+            self::ALGORITHMS[$algorithm]
+        );
+
+        if ($result !== 1) {
+            throw new SignatureInvalidException('JWT signature verification failed');
+        }
+    }
+
+    /**
+     * @throws SignatureInvalidException
+     */
+    private function resolvePublicKey(): OpenSSLAsymmetricKey
+    {
+        $publicKey = openssl_pkey_get_public($this->certificate);
+        if ($publicKey === false) {
+            throw new SignatureInvalidException(
+                'The ESIA signing certificate is not a valid public key or certificate'
+            );
+        }
+
+        return $publicKey;
+    }
+}

--- a/src/Esia/Token/SignatureVerifierInterface.php
+++ b/src/Esia/Token/SignatureVerifierInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Esia\Token;
+
+use Esia\Exceptions\SignatureInvalidException;
+
+/**
+ * Verifies the cryptographic signature of a JWT.
+ *
+ * Implementations are algorithm specific. The default
+ * {@see OpenSslSignatureVerifier} covers RSA (RS256/384/512) and, when the
+ * OpenSSL GOST engine is available, the GOST 34.10-2012 algorithms used by
+ * ESIA in production. Integrators may provide their own implementation (e.g.
+ * a CryptoPro-backed verifier) to support other environments.
+ */
+interface SignatureVerifierInterface
+{
+    /**
+     * @param string $signingInput The JWT signing input ("header.payload").
+     * @param string $signature    The raw (already base64url-decoded) signature.
+     * @param string $algorithm    The value of the JWT "alg" header.
+     *
+     * @throws SignatureInvalidException When the signature is invalid or the
+     *                                   algorithm is not supported.
+     */
+    public function verify(string $signingInput, string $signature, string $algorithm): void;
+}

--- a/src/Esia/Token/TokenValidatorInterface.php
+++ b/src/Esia/Token/TokenValidatorInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Esia\Token;
+
+use Esia\Exceptions\InvalidTokenException;
+
+/**
+ * Validates a JWT (access token) received from ESIA.
+ *
+ * Implementations must verify the token signature against the ESIA signing
+ * certificate and validate the standard claims (iss, aud/client_id, exp, nbf,
+ * iat). This makes validation pluggable so integrators can supply the current
+ * ESIA certificate or a custom validation strategy.
+ */
+interface TokenValidatorInterface
+{
+    /**
+     * Validate the given JWT and return its decoded claims (the payload).
+     *
+     * @param string $token The raw JWT (header.payload.signature).
+     *
+     * @return array<string, mixed> The decoded claims.
+     *
+     * @throws InvalidTokenException When the signature or any claim is invalid.
+     */
+    public function validate(string $token): array;
+}

--- a/tests/unit/OpenIdTest.php
+++ b/tests/unit/OpenIdTest.php
@@ -199,6 +199,104 @@ class OpenIdTest extends Unit
     }
 
     /**
+     * @throws InvalidConfigurationException
+     * @throws AbstractEsiaException
+     */
+    public function testGetTokenValidatesJwtWhenValidatorSet(): void
+    {
+        $keyResource = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+        openssl_pkey_export($keyResource, $privateKey);
+        $certificate = openssl_pkey_get_details($keyResource)['key'];
+
+        $oid = 456;
+        $token = $this->signJwt($privateKey, [
+            'iss' => 'http://esia.gosuslugi.ru/',
+            'aud' => 'INSP03211',
+            'exp' => time() + 3600,
+            'urn:esia:sbj_id' => $oid,
+        ]);
+
+        $config = new Config($this->config);
+        $client = $this->buildClientWithResponses([
+            new Response(200, [], json_encode(['access_token' => $token])),
+        ]);
+        $openId = new OpenId($config, $client);
+        $openId->setSigner($this->stubSigner());
+        $openId->setTokenValidator(new \Esia\Token\JwtValidator(
+            new \Esia\Token\OpenSslSignatureVerifier($certificate),
+            'http://esia.gosuslugi.ru/',
+            'INSP03211'
+        ));
+
+        self::assertSame($token, $openId->getToken('code'));
+        self::assertSame((string) $oid, $openId->getConfig()->getOid());
+    }
+
+    /**
+     * @throws InvalidConfigurationException
+     * @throws AbstractEsiaException
+     */
+    public function testGetTokenRejectsTamperedJwtWhenValidatorSet(): void
+    {
+        $keyResource = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+        openssl_pkey_export($keyResource, $privateKey);
+        $certificate = openssl_pkey_get_details($keyResource)['key'];
+
+        $token = $this->signJwt($privateKey, [
+            'iss' => 'http://esia.gosuslugi.ru/',
+            'aud' => 'INSP03211',
+            'exp' => time() + 3600,
+            'urn:esia:sbj_id' => 456,
+        ]);
+        [$header, $payload] = explode('.', $token);
+        $tampered = $header . '.' . $payload . '.' . rtrim(strtr(base64_encode('forged'), '+/', '-_'), '=');
+
+        $config = new Config($this->config);
+        $client = $this->buildClientWithResponses([
+            new Response(200, [], json_encode(['access_token' => $tampered])),
+        ]);
+        $openId = new OpenId($config, $client);
+        $openId->setSigner($this->stubSigner());
+        $openId->setTokenValidator(new \Esia\Token\JwtValidator(
+            new \Esia\Token\OpenSslSignatureVerifier($certificate),
+            'http://esia.gosuslugi.ru/',
+            'INSP03211'
+        ));
+
+        $this->expectException(\Esia\Exceptions\SignatureInvalidException::class);
+        $openId->getToken('code');
+    }
+
+    private function stubSigner(): \Esia\Signer\SignerInterface
+    {
+        return new class implements \Esia\Signer\SignerInterface {
+            public function sign(string $message): string
+            {
+                return 'signed';
+            }
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $claims
+     */
+    private function signJwt(string $privateKey, array $claims): string
+    {
+        $encode = static fn (string $data): string => rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+        $header = $encode((string) json_encode(['typ' => 'JWT', 'alg' => 'RS256']));
+        $payload = $encode((string) json_encode($claims));
+        openssl_sign($header . '.' . $payload, $signature, $privateKey, OPENSSL_ALGO_SHA256);
+
+        return $header . '.' . $payload . '.' . $encode($signature);
+    }
+
+    /**
      * Client with prepared responses
      *
      * @param ResponseInterface[] $responses

--- a/tests/unit/OpenIdTest.php
+++ b/tests/unit/OpenIdTest.php
@@ -273,6 +273,104 @@ class OpenIdTest extends Unit
         $openId->getToken('code');
     }
 
+    /**
+     * Exercises the advertised opt-in path where validation is enabled purely
+     * through Config (esiaCertPath / esiaTokenIssuer), with no manual
+     * setTokenValidator() call.
+     *
+     * @throws InvalidConfigurationException
+     * @throws AbstractEsiaException
+     */
+    public function testGetTokenValidatesViaEsiaCertPathConfig(): void
+    {
+        [$certPath, $privateKey] = $this->writeCertFixture();
+
+        $oid = 789;
+        $token = $this->signJwt($privateKey, [
+            'iss' => 'http://esia.gosuslugi.ru/',
+            'aud' => 'INSP03211',
+            'exp' => time() + 3600,
+            'urn:esia:sbj_id' => $oid,
+        ]);
+
+        $config = new Config($this->config + [
+            'esiaCertPath' => $certPath,
+            'esiaTokenIssuer' => 'http://esia.gosuslugi.ru/',
+            'tokenLeeway' => 30,
+        ]);
+        $client = $this->buildClientWithResponses([
+            new Response(200, [], json_encode(['access_token' => $token])),
+        ]);
+        $openId = new OpenId($config, $client);
+        $openId->setSigner($this->stubSigner());
+
+        self::assertSame($token, $openId->getToken('code'));
+        self::assertSame((string) $oid, $openId->getConfig()->getOid());
+    }
+
+    /**
+     * The audience for the auto-configured validator comes from clientId, so a
+     * token minted for a different audience must be rejected.
+     *
+     * @throws InvalidConfigurationException
+     * @throws AbstractEsiaException
+     */
+    public function testGetTokenViaConfigRejectsWrongAudience(): void
+    {
+        [$certPath, $privateKey] = $this->writeCertFixture();
+
+        $token = $this->signJwt($privateKey, [
+            'iss' => 'http://esia.gosuslugi.ru/',
+            'aud' => 'SOMEONE_ELSE',
+            'exp' => time() + 3600,
+            'urn:esia:sbj_id' => 1,
+        ]);
+
+        $config = new Config($this->config + [
+            'esiaCertPath' => $certPath,
+            'esiaTokenIssuer' => 'http://esia.gosuslugi.ru/',
+        ]);
+        $client = $this->buildClientWithResponses([
+            new Response(200, [], json_encode(['access_token' => $token])),
+        ]);
+        $openId = new OpenId($config, $client);
+        $openId->setSigner($this->stubSigner());
+
+        $this->expectException(\Esia\Exceptions\InvalidClaimException::class);
+        $openId->getToken('code');
+    }
+
+    /**
+     * A validated token that lacks the ESIA subject id must be rejected instead
+     * of storing an empty oid.
+     *
+     * @throws InvalidConfigurationException
+     * @throws AbstractEsiaException
+     */
+    public function testGetTokenRejectsTokenWithoutSubjectId(): void
+    {
+        [$certPath, $privateKey] = $this->writeCertFixture();
+
+        $token = $this->signJwt($privateKey, [
+            'iss' => 'http://esia.gosuslugi.ru/',
+            'aud' => 'INSP03211',
+            'exp' => time() + 3600,
+        ]);
+
+        $config = new Config($this->config + [
+            'esiaCertPath' => $certPath,
+            'esiaTokenIssuer' => 'http://esia.gosuslugi.ru/',
+        ]);
+        $client = $this->buildClientWithResponses([
+            new Response(200, [], json_encode(['access_token' => $token])),
+        ]);
+        $openId = new OpenId($config, $client);
+        $openId->setSigner($this->stubSigner());
+
+        $this->expectException(\Esia\Exceptions\InvalidClaimException::class);
+        $openId->getToken('code');
+    }
+
     private function stubSigner(): \Esia\Signer\SignerInterface
     {
         return new class implements \Esia\Signer\SignerInterface {
@@ -281,6 +379,29 @@ class OpenIdTest extends Unit
                 return 'signed';
             }
         };
+    }
+
+    /**
+     * Generate a self-signed RSA certificate, write it to the output dir and
+     * return [certPath, privateKeyPem].
+     *
+     * @return array{string, string}
+     */
+    private function writeCertFixture(): array
+    {
+        $keyResource = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+        $csr = openssl_csr_new(['commonName' => 'ESIA'], $keyResource);
+        $x509 = openssl_csr_sign($csr, null, $keyResource, 1);
+        openssl_x509_export($x509, $certPem);
+        openssl_pkey_export($keyResource, $privateKey);
+
+        $certPath = codecept_output_dir('esia-cert-' . uniqid('', true) . '.pem');
+        file_put_contents($certPath, $certPem);
+
+        return [$certPath, $privateKey];
     }
 
     /**

--- a/tests/unit/OpenIdTest.php
+++ b/tests/unit/OpenIdTest.php
@@ -382,8 +382,10 @@ class OpenIdTest extends Unit
     }
 
     /**
-     * Generate a self-signed RSA certificate, write it to the output dir and
-     * return [certPath, privateKeyPem].
+     * Generate an RSA key pair, write its public key (PEM) to the output dir
+     * and return [publicKeyPath, privateKeyPem]. A bare public key is enough
+     * for {@see OpenSslSignatureVerifier} and avoids CSR/X.509 signing, which
+     * is unavailable under the GOST-configured OpenSSL used in CI.
      *
      * @return array{string, string}
      */
@@ -393,13 +395,11 @@ class OpenIdTest extends Unit
             'private_key_bits' => 2048,
             'private_key_type' => OPENSSL_KEYTYPE_RSA,
         ]);
-        $csr = openssl_csr_new(['commonName' => 'ESIA'], $keyResource);
-        $x509 = openssl_csr_sign($csr, null, $keyResource, 1);
-        openssl_x509_export($x509, $certPem);
         openssl_pkey_export($keyResource, $privateKey);
+        $publicKey = openssl_pkey_get_details($keyResource)['key'];
 
-        $certPath = codecept_output_dir('esia-cert-' . uniqid('', true) . '.pem');
-        file_put_contents($certPath, $certPem);
+        $certPath = codecept_output_dir('esia-pub-' . uniqid('', true) . '.pem');
+        file_put_contents($certPath, $publicKey);
 
         return [$certPath, $privateKey];
     }

--- a/tests/unit/Token/JwtValidatorTest.php
+++ b/tests/unit/Token/JwtValidatorTest.php
@@ -53,10 +53,16 @@ class JwtValidatorTest extends Unit
      */
     private function makeToken(array $claims, string $alg = 'RS256', bool $tamper = false): string
     {
+        $algos = [
+            'RS256' => OPENSSL_ALGO_SHA256,
+            'RS384' => OPENSSL_ALGO_SHA384,
+            'RS512' => OPENSSL_ALGO_SHA512,
+        ];
+
         $header = self::base64UrlEncode((string) json_encode(['typ' => 'JWT', 'alg' => $alg]));
         $payload = self::base64UrlEncode((string) json_encode($claims));
 
-        openssl_sign($header . '.' . $payload, $signature, $this->privateKey, OPENSSL_ALGO_SHA256);
+        openssl_sign($header . '.' . $payload, $signature, $this->privateKey, $algos[$alg]);
         if ($tamper) {
             $signature = strrev($signature);
         }
@@ -91,6 +97,57 @@ class JwtValidatorTest extends Unit
 
         self::assertSame(123, $claims['urn:esia:sbj_id']);
         self::assertSame(self::ISSUER, $claims['iss']);
+    }
+
+    /**
+     * @dataProvider rsaAlgorithmProvider
+     */
+    public function testValidatesEachRsaAlgorithm(string $alg): void
+    {
+        $token = $this->makeToken($this->validClaims(), $alg);
+
+        $claims = $this->validator()->validate($token);
+
+        self::assertSame(123, $claims['urn:esia:sbj_id']);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public function rsaAlgorithmProvider(): array
+    {
+        return [
+            'RS256' => ['RS256'],
+            'RS384' => ['RS384'],
+            'RS512' => ['RS512'],
+        ];
+    }
+
+    /**
+     * A signature made with a different digest than the header advertises must
+     * be rejected (guards the alg→digest mapping).
+     */
+    public function testRejectsAlgorithmMismatch(): void
+    {
+        $header = self::base64UrlEncode((string) json_encode(['typ' => 'JWT', 'alg' => 'RS256']));
+        $payload = self::base64UrlEncode((string) json_encode($this->validClaims()));
+        openssl_sign($header . '.' . $payload, $signature, $this->privateKey, OPENSSL_ALGO_SHA512);
+        $token = $header . '.' . $payload . '.' . self::base64UrlEncode($signature);
+
+        $this->expectException(SignatureInvalidException::class);
+        $this->validator()->validate($token);
+    }
+
+    public function testRejectsUnsupportedAlgorithm(): void
+    {
+        $token = $this->makeToken($this->validClaims());
+        // Swap the header to an unsupported algorithm while keeping a signature.
+        [, $payload, $signature] = explode('.', $token);
+        $header = self::base64UrlEncode((string) json_encode(['typ' => 'JWT', 'alg' => 'HS256']));
+        $forged = $header . '.' . $payload . '.' . $signature;
+
+        $this->expectException(SignatureInvalidException::class);
+        $this->validator()->validate($forged);
     }
 
     public function testAcceptsClientIdAsAudience(): void
@@ -157,6 +214,44 @@ class JwtValidatorTest extends Unit
 
         $this->expectException(InvalidClaimException::class);
         $this->validator()->validate($token);
+    }
+
+    /**
+     * @dataProvider nonNumericTimeClaimProvider
+     */
+    public function testNonNumericTimeClaimThrows(string $claim): void
+    {
+        // Sign a properly-signed token whose time claim is a non-numeric string.
+        $token = $this->makeToken($this->validClaims([$claim => 'invalid']));
+
+        $this->expectException(InvalidClaimException::class);
+        $this->validator()->validate($token);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public function nonNumericTimeClaimProvider(): array
+    {
+        return [
+            'exp' => ['exp'],
+            'nbf' => ['nbf'],
+            'iat' => ['iat'],
+        ];
+    }
+
+    public function testAcceptsNumericStringTimeClaims(): void
+    {
+        $now = time();
+        $token = $this->makeToken($this->validClaims([
+            'exp' => (string) ($now + 3600),
+            'nbf' => (string) $now,
+            'iat' => (string) $now,
+        ]));
+
+        $claims = $this->validator()->validate($token);
+
+        self::assertSame(123, $claims['urn:esia:sbj_id']);
     }
 
     public function testUnsignedTokenIsRejected(): void

--- a/tests/unit/Token/JwtValidatorTest.php
+++ b/tests/unit/Token/JwtValidatorTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\unit\Token;
+
+use Codeception\Test\Unit;
+use Esia\Exceptions\InvalidClaimException;
+use Esia\Exceptions\SignatureInvalidException;
+use Esia\Exceptions\TokenExpiredException;
+use Esia\Token\JwtValidator;
+use Esia\Token\OpenSslSignatureVerifier;
+
+class JwtValidatorTest extends Unit
+{
+    private const ISSUER = 'http://esia.gosuslugi.ru/';
+    private const AUDIENCE = 'INSP03211';
+
+    private string $certificate;
+
+    private string $privateKey;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $resource = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+        self::assertNotFalse($resource, 'Unable to generate an RSA key for the test');
+
+        openssl_pkey_export($resource, $privateKey);
+        $this->privateKey = $privateKey;
+
+        $details = openssl_pkey_get_details($resource);
+        self::assertIsArray($details);
+        $this->certificate = $details['key'];
+    }
+
+    private function validator(int $leeway = 60): JwtValidator
+    {
+        return new JwtValidator(
+            new OpenSslSignatureVerifier($this->certificate),
+            self::ISSUER,
+            self::AUDIENCE,
+            $leeway
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $claims
+     */
+    private function makeToken(array $claims, string $alg = 'RS256', bool $tamper = false): string
+    {
+        $header = self::base64UrlEncode((string) json_encode(['typ' => 'JWT', 'alg' => $alg]));
+        $payload = self::base64UrlEncode((string) json_encode($claims));
+
+        openssl_sign($header . '.' . $payload, $signature, $this->privateKey, OPENSSL_ALGO_SHA256);
+        if ($tamper) {
+            $signature = strrev($signature);
+        }
+
+        return $header . '.' . $payload . '.' . self::base64UrlEncode($signature);
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     *
+     * @return array<string, mixed>
+     */
+    private function validClaims(array $overrides = []): array
+    {
+        $now = time();
+
+        return $overrides + [
+            'iss' => self::ISSUER,
+            'aud' => self::AUDIENCE,
+            'iat' => $now,
+            'nbf' => $now,
+            'exp' => $now + 3600,
+            'urn:esia:sbj_id' => 123,
+        ];
+    }
+
+    public function testValidTokenReturnsClaims(): void
+    {
+        $token = $this->makeToken($this->validClaims());
+
+        $claims = $this->validator()->validate($token);
+
+        self::assertSame(123, $claims['urn:esia:sbj_id']);
+        self::assertSame(self::ISSUER, $claims['iss']);
+    }
+
+    public function testAcceptsClientIdAsAudience(): void
+    {
+        $claims = $this->validClaims();
+        unset($claims['aud']);
+        $claims['client_id'] = self::AUDIENCE;
+
+        $result = $this->validator()->validate($this->makeToken($claims));
+
+        self::assertSame(self::AUDIENCE, $result['client_id']);
+    }
+
+    public function testExpiredTokenThrows(): void
+    {
+        $token = $this->makeToken($this->validClaims([
+            'exp' => time() - 3600,
+            'iat' => time() - 7200,
+            'nbf' => time() - 7200,
+        ]));
+
+        $this->expectException(TokenExpiredException::class);
+        $this->validator()->validate($token);
+    }
+
+    public function testNotYetValidTokenThrows(): void
+    {
+        $token = $this->makeToken($this->validClaims(['nbf' => time() + 3600]));
+
+        $this->expectException(TokenExpiredException::class);
+        $this->validator()->validate($token);
+    }
+
+    public function testTamperedSignatureThrows(): void
+    {
+        $token = $this->makeToken($this->validClaims(), 'RS256', true);
+
+        $this->expectException(SignatureInvalidException::class);
+        $this->validator()->validate($token);
+    }
+
+    public function testTamperedPayloadThrows(): void
+    {
+        $token = $this->makeToken($this->validClaims());
+        [$header, , $signature] = explode('.', $token);
+        $forged = self::base64UrlEncode((string) json_encode($this->validClaims(['urn:esia:sbj_id' => 999])));
+        $tampered = $header . '.' . $forged . '.' . $signature;
+
+        $this->expectException(SignatureInvalidException::class);
+        $this->validator()->validate($tampered);
+    }
+
+    public function testWrongAudienceThrows(): void
+    {
+        $token = $this->makeToken($this->validClaims(['aud' => 'SOMEONE_ELSE']));
+
+        $this->expectException(InvalidClaimException::class);
+        $this->validator()->validate($token);
+    }
+
+    public function testWrongIssuerThrows(): void
+    {
+        $token = $this->makeToken($this->validClaims(['iss' => 'http://evil.example/']));
+
+        $this->expectException(InvalidClaimException::class);
+        $this->validator()->validate($token);
+    }
+
+    public function testUnsignedTokenIsRejected(): void
+    {
+        $header = self::base64UrlEncode((string) json_encode(['typ' => 'JWT', 'alg' => 'none']));
+        $payload = self::base64UrlEncode((string) json_encode($this->validClaims()));
+        $token = $header . '.' . $payload . '.';
+
+        $this->expectException(SignatureInvalidException::class);
+        $this->validator()->validate($token);
+    }
+
+    public function testMalformedTokenIsRejected(): void
+    {
+        $this->expectException(InvalidClaimException::class);
+        $this->validator()->validate('not-a-jwt');
+    }
+
+    private static function base64UrlEncode(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+}


### PR DESCRIPTION
Closes #68.

## What

Adds **pluggable, opt-in JWT validation** for the access token returned by ESIA. Previously the library decoded the token payload without verifying its signature or claims — accepting an unverified token undermines the auth flow.

## How

- **`Esia\Token\TokenValidatorInterface`** + default **`JwtValidator`**:
  - Verifies the signature via **`SignatureVerifierInterface`** / **`OpenSslSignatureVerifier`** (RSA `RS256/384/512` out of the box; GOST-2012 algorithms when the OpenSSL GOST engine is present).
  - Validates standard claims: `exp`, `nbf`, `iat` (with configurable leeway), `iss` and audience (`aud`/`client_id`).
- **Clear exceptions** under `InvalidTokenException`:
  - `SignatureInvalidException` — invalid/missing signature or unsupported alg.
  - `TokenExpiredException` — expired (`exp`) or not-yet-valid (`nbf`).
  - `InvalidClaimException` — wrong `iss` / audience / malformed token.
- **Integration**: `OpenId::setTokenValidator()` to plug a validator; `Config` gains `esiaCertPath`, `esiaTokenIssuer`, `tokenLeeway` to auto-enable validation. `getToken()` validates the token before accepting it when a validator is configured.

## Backward compatibility

Validation is **opt-in** — with no `esiaCertPath`/validator set, `getToken()` behaves exactly as before (decodes payload only). No breaking changes.

## Pluggability

Integrators can supply the current ESIA certificate via `esiaCertPath`, or provide a fully custom `TokenValidatorInterface` (e.g. a CryptoPro-backed GOST verifier) via `setTokenValidator()`.

## Tests

Fixture-based tests (runtime-generated RSA keys) covering **valid, expired, not-yet-valid, tampered signature, tampered payload, wrong-audience, wrong-issuer, unsigned (`alg:none`) and malformed** tokens, plus `OpenId` integration tests (valid + tampered). PHPStan level 5 clean; `composer validate --strict` passes.

## Acceptance criteria

- [x] Token signature + standard claims validated before the token is accepted.
- [x] Clear exception on invalid signature / expired / wrong audience.
- [x] Fixture-based tests covering valid, expired, tampered, and wrong-audience tokens.