### PR TITLE
ci: add php-cs-fixer and composer-normalize (#73)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,27 @@ jobs:
       - name: PHPStan
         run: vendor/bin/phpstan analyse --no-progress
 
+  coding-standards:
+    runs-on: ubuntu-24.04
+    name: Coding standards
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: openssl
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction
+
+      - name: Check composer.json normalization
+        run: composer normalize --dry-run --no-interaction
+
+      - name: PHP-CS-Fixer
+        run: vendor/bin/php-cs-fixer fix --dry-run --diff --using-cache=no
+
   gost-roundtrip:
     runs-on: ubuntu-24.04
     name: GOST signing round-trip

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+$finder = PhpCsFixer\Finder::create()
+    ->in([__DIR__ . '/src', __DIR__ . '/tests'])
+    ->exclude(['_support/_generated', '_output'])
+    ->name('*.php');
+
+return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(false)
+    ->setRules([
+        '@PSR12' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'no_unused_imports' => true,
+        'ordered_imports' => ['sort_algorithm' => 'alpha'],
+        'single_quote' => true,
+        'trailing_comma_in_multiline' => true,
+        'no_trailing_whitespace' => true,
+        'no_whitespace_in_blank_line' => true,
+    ])
+    ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,36 @@
 {
   "name": "fr05t1k/esia",
-  "license": "MIT",
   "description": "OpenID ESIA authenticating",
+  "license": "MIT",
   "keywords": [
     "esia",
     "openid",
     "egov"
   ],
+  "require": {
+    "php": "^8.3",
+    "ext-json": "*",
+    "ext-openssl": "*",
+    "php-http/discovery": "^1.19",
+    "psr/http-client": "^1.0",
+    "psr/http-factory": "^1.0",
+    "psr/http-message": "^1.1 || ^2.0",
+    "psr/log": "^1.1 || ^2.0 || ^3.0"
+  },
+  "require-dev": {
+    "codeception/codeception": "^5.1",
+    "codeception/module-asserts": "^3.0",
+    "ergebnis/composer-normalize": "^2.43",
+    "friendsofphp/php-cs-fixer": "^3.64",
+    "nyholm/psr7": "^1.8",
+    "php-http/mock-client": "^1.6",
+    "phpstan/phpstan": "^2.0"
+  },
+  "suggest": {
+    "guzzlehttp/guzzle": "PSR-18 HTTP client and PSR-17 factories (^7.9)",
+    "nyholm/psr7": "Lightweight PSR-7/PSR-17 message and factory implementation",
+    "symfony/http-client": "Alternative PSR-18 HTTP client"
+  },
   "autoload": {
     "psr-4": {
       "Esia\\": "src/Esia"
@@ -17,36 +41,15 @@
       "tests\\": "tests"
     }
   },
-  "require": {
-    "php": "^8.3",
-    "ext-json": "*",
-    "ext-openssl": "*",
-    "psr/log": "^1.1 || ^2.0 || ^3.0",
-    "psr/http-message": "^1.1 || ^2.0",
-    "psr/http-client": "^1.0",
-    "psr/http-factory": "^1.0",
-    "php-http/discovery": "^1.19"
-  },
-  "require-dev": {
-    "codeception/codeception": "^5.1",
-    "codeception/module-asserts": "^3.0",
-    "phpstan/phpstan": "^2.0",
-    "nyholm/psr7": "^1.8",
-    "php-http/mock-client": "^1.6"
-  },
-  "suggest": {
-    "guzzlehttp/guzzle": "PSR-18 HTTP client and PSR-17 factories (^7.9)",
-    "symfony/http-client": "Alternative PSR-18 HTTP client",
-    "nyholm/psr7": "Lightweight PSR-7/PSR-17 message and factory implementation"
-  },
   "config": {
+    "allow-plugins": {
+      "codeception/c3": true,
+      "ergebnis/composer-normalize": true,
+      "php-http/discovery": true
+    },
     "platform": {
       "php": "8.3.0"
     },
-    "sort-packages": true,
-    "allow-plugins": {
-      "codeception/c3": true,
-      "php-http/discovery": true
-    }
+    "sort-packages": true
   }
 }

--- a/src/Esia/Config.php
+++ b/src/Esia/Config.php
@@ -154,7 +154,7 @@ class Config
     {
         return $this->certPath;
     }
-    
+
     public function getOid(): string
     {
         return $this->oid;

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 // This is global bootstrap for autoloading
 require_once __DIR__ . '/../vendor/autoload.php';
 

--- a/tests/_support/Helper/Unit.php
+++ b/tests/_support/Helper/Unit.php
@@ -1,5 +1,7 @@
 <?php
+
 namespace Helper;
+
 // here you can define custom actions
 // all public methods declared in helper class will be available in $I
 

--- a/tests/_support/UnitTester.php
+++ b/tests/_support/UnitTester.php
@@ -20,7 +20,7 @@ class UnitTester extends \Codeception\Actor
 {
     use _generated\UnitTesterActions;
 
-   /**
-    * Define custom actions here
-    */
+    /**
+     * Define custom actions here
+     */
 }

--- a/tests/unit/OfflineFlowTest.php
+++ b/tests/unit/OfflineFlowTest.php
@@ -240,7 +240,7 @@ class OfflineFlowTest extends Unit
 
     private function stubSigner(): SignerInterface
     {
-        return new class implements SignerInterface {
+        return new class () implements SignerInterface {
             public function sign(string $message): string
             {
                 return 'signed';

--- a/tests/unit/OpenIdCliOpensslTest.php
+++ b/tests/unit/OpenIdCliOpensslTest.php
@@ -9,7 +9,6 @@ use Esia\OpenId;
 use Esia\Signer\CliSignerPKCS7;
 use Nyholm\Psr7\Response;
 
-
 class OpenIdCliOpensslTest extends OpenIdTest
 {
     /**

--- a/tests/unit/OpenIdTest.php
+++ b/tests/unit/OpenIdTest.php
@@ -373,7 +373,7 @@ class OpenIdTest extends Unit
 
     private function stubSigner(): \Esia\Signer\SignerInterface
     {
-        return new class implements \Esia\Signer\SignerInterface {
+        return new class () implements \Esia\Signer\SignerInterface {
             public function sign(string $message): string
             {
                 return 'signed';

--- a/tests/unit/_bootstrap.php
+++ b/tests/unit/_bootstrap.php
@@ -1,2 +1,3 @@
 <?php
+
 // Here you can initialize variables that will be available to your tests


### PR DESCRIPTION
Completes the code-quality tooling tracked in #73.

### Already landed (via #79)
- PHPStan, `composer validate --strict`, and the PHP **8.3 / 8.4** matrix.

### This PR adds the remaining pieces
- **php-cs-fixer** — `friendsofphp/php-cs-fixer` dev dependency + `.php-cs-fixer.php` (PSR-12 base, short arrays, ordered/unused imports, single quotes, trailing-comma, no trailing whitespace). Excludes Codeception's generated `tests/_support/_generated` and `tests/_output`.
- **composer-normalize** — `ergebnis/composer-normalize` plugin; `composer.json` normalized.
- **CI** — new `Coding standards` job runs `composer normalize --dry-run` and `php-cs-fixer fix --dry-run --diff`.
- Applied the fixer across `src/` and `tests/` — whitespace and brace-placement only, no behavioral changes.

### Acceptance criteria (#73)
- [x] phpstan, cs-fixer, and `composer validate --strict` run in CI
- [x] Config files committed (`phpstan.neon`, `.php-cs-fixer.php`)
- [x] Matrix includes PHP 8.4

Verified locally: `php-cs-fixer --dry-run` clean, `composer normalize --dry-run` clean, phpstan OK, unit suite green (except the known GOST-CLI test that only passes with the GOST OpenSSL engine in CI).