### PR TITLE
feat: first-class GOST-2012 / CryptoPro signers (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,54 @@ GOST-подписи через CryptoPro) через `\Esia\OpenId::setTokenVali
 `\Esia\Token\OpenSslSignatureVerifier` (RSA из коробки; алгоритмы GOST-2012 —
 при наличии GOST-движка в OpenSSL).
 
+## Подпись запросов (сигнеры)
+
+Для получения токена запрос к ЕСИА должен быть подписан. ЕСИА требует подпись
+**ГОСТ Р 34.10-2012** (RSA больше не поддерживается в продуктивной среде).
+Сигнер задаётся через `\Esia\OpenId::setSigner()` и должен реализовывать
+`\Esia\Signer\SignerInterface`. Доступны следующие реализации:
+
+| Сигнер | Механизм | Требования |
+| --- | --- | --- |
+| `\Esia\Signer\SignerPKCS7` | Нативный `openssl_pkcs7_sign()` | Стандартный PHP с `ext-openssl`. **Не умеет ГОСТ** в обычной сборке OpenSSL — подходит только для тестов/RSA. |
+| `\Esia\Signer\CliSignerPKCS7` | Вызов `openssl smime -engine gost` | OpenSSL, собранный с GOST-движком (`libengine-gost-openssl1.1`), в `PATH`. Ключ и сертификат ГОСТ в PEM. |
+| `\Esia\Signer\CliCryptoProSigner` | Вызов утилиты `cryptcp` | Установленный **КриптоПро CSP** с утилитой `cryptcp`. Сертификат ГОСТ в хранилище CSP, указывается по SHA-1 отпечатку. |
+| `\Esia\Signer\CryptoProSigner` | PHP-расширение КриптоПро (`\CPStore`/`\CPSigner`) | Проприетарное PHP-расширение КриптоПро. Сертификат ГОСТ в хранилище `My` текущего пользователя. |
+
+Пример с CLI-сигнером ГОСТ (OpenSSL + GOST-движок):
+
+```php
+$esia->setSigner(new \Esia\Signer\CliSignerPKCS7(
+    '/path/to/gost-cert.pem',
+    '/path/to/gost-key.pem',
+    'key-password',
+    '/tmp'
+));
+```
+
+Пример с КриптоПро через утилиту `cryptcp` (отпечаток — SHA-1 сертификата в
+хранилище CSP):
+
+```php
+$esia->setSigner(new \Esia\Signer\CliCryptoProSigner(
+    '/opt/cprocsp/bin/amd64/cryptcp', // путь до cryptcp
+    '745187e5c161cd2e3130d886f9df4492fa270685', // отпечаток сертификата
+    'pin', // PIN контейнера (если задан)
+    '/tmp' // каталог для временных файлов
+));
+```
+
+Пример с КриптоПро через PHP-расширение:
+
+```php
+$esia->setSigner(new \Esia\Signer\CryptoProSigner(
+    '745187e5c161cd2e3130d886f9df4492fa270685', // отпечаток сертификата
+    'pin' // PIN контейнера (если задан)
+));
+```
+
+Все сигнеры поддерживают PSR-3 логгер через `setLogger()`.
+
 
 
 Токен - jwt токен которые вы получаете от ЕСИА для дальнейшего взаимодействия

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,4 +2,8 @@ parameters:
     level: 5
     paths:
         - src
+    excludePaths:
+        # Relies on the proprietary CryptoPro PHP extension (\CPStore, \CPSigner,
+        # …) which has no stubs and is unavailable in CI.
+        - src/Esia/Signer/CryptoProSigner.php
     treatPhpDocTypesAsCertain: false

--- a/src/Esia/Signer/AbstractSignerPKCS7.php
+++ b/src/Esia/Signer/AbstractSignerPKCS7.php
@@ -17,6 +17,7 @@ use Psr\Log\NullLogger;
 abstract class AbstractSignerPKCS7
 {
     use LoggerAwareTrait;
+    use UrlSafeSignatureTrait;
 
     /**
      * @param string $certPath Path to the certificate
@@ -70,13 +71,5 @@ abstract class AbstractSignerPKCS7
         } catch (Exception $e) {
             throw new SignFailException('Cannot generate random string', 0, $e);
         }
-    }
-
-    /**
-     * Url safe for base64
-     */
-    protected function urlSafe(string $string): string
-    {
-        return rtrim(strtr(trim($string), '+/', '-_'), '=');
     }
 }

--- a/src/Esia/Signer/CliCryptoProSigner.php
+++ b/src/Esia/Signer/CliCryptoProSigner.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Esia\Signer;
+
+use Esia\Signer\Exceptions\NoSuchTmpDirException;
+use Esia\Signer\Exceptions\SignFailException;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
+
+/**
+ * Signs messages with CryptoPro CSP via its command-line tool `cryptcp`.
+ *
+ * Runtime requirements:
+ *  - CryptoPro CSP installed with the `cryptcp` utility available.
+ *  - A GOST R 34.10-2012 certificate + private key present in the CSP key store,
+ *    referenced by its SHA-1 thumbprint.
+ *
+ * @see https://docs.cryptopro.ru/cades/utilities/cryptcp
+ */
+final class CliCryptoProSigner implements SignerInterface
+{
+    use LoggerAwareTrait;
+    use UrlSafeSignatureTrait;
+
+    private string $tempDir;
+
+    /**
+     * @param string $toolPath Path to (or name of) the `cryptcp` executable
+     * @param string $thumbprint SHA-1 thumbprint of the signing certificate in the CSP store
+     * @param string|null $pin PIN/password for the private key container, if any
+     * @param string|null $tempDir Writable directory for temporary files (defaults to the system temp dir)
+     *
+     * @throws NoSuchTmpDirException
+     */
+    public function __construct(
+        private string $toolPath,
+        private string $thumbprint,
+        private ?string $pin = null,
+        ?string $tempDir = null
+    ) {
+        $this->tempDir = $tempDir ?? sys_get_temp_dir();
+        $this->logger = new NullLogger();
+
+        if (!file_exists($this->tempDir)) {
+            throw new NoSuchTmpDirException('Temporary folder is not found');
+        }
+        if (!is_writable($this->tempDir)) {
+            throw new NoSuchTmpDirException('Temporary folder is not writable');
+        }
+    }
+
+    /**
+     * @throws SignFailException
+     */
+    public function sign(string $message): string
+    {
+        $messageFile = tempnam($this->tempDir, 'cryptcp');
+        if ($messageFile === false) {
+            throw new SignFailException('Cannot create a temporary file for signing');
+        }
+        file_put_contents($messageFile, $message);
+
+        try {
+            return $this->signFile($messageFile);
+        } finally {
+            if (file_exists($messageFile)) {
+                unlink($messageFile);
+            }
+        }
+    }
+
+    /**
+     * @throws SignFailException
+     */
+    private function signFile(string $messageFile): string
+    {
+        $command = escapeshellarg($this->toolPath)
+            . ' -signf -dir ' . escapeshellarg($this->tempDir)
+            . ' -cert -thumbprint ' . escapeshellarg($this->thumbprint);
+        if ($this->pin !== null && $this->pin !== '') {
+            $command .= ' -pin ' . escapeshellarg($this->pin);
+        }
+        $command .= ' ' . escapeshellarg($messageFile) . ' 2>&1';
+
+        $output = [];
+        $resultCode = 0;
+        exec($command, $output, $resultCode);
+
+        if ($resultCode !== 0) {
+            $errors = implode("\n", $output);
+            $this->logger->error('Sign fail');
+            $this->logger->error('cryptcp error: ' . $errors);
+            throw new SignFailException('Failure signing: ' . $errors);
+        }
+
+        $signatureFile = $messageFile . '.sgn';
+        $signed = file_get_contents($signatureFile);
+        if ($signed === false || $signed === '') {
+            throw new SignFailException(sprintf('Cannot read the signature file %s', $signatureFile));
+        }
+        unlink($signatureFile);
+
+        return $this->normalizeBase64Signature($signed);
+    }
+}

--- a/src/Esia/Signer/CliCryptoProSigner.php
+++ b/src/Esia/Signer/CliCryptoProSigner.php
@@ -43,7 +43,7 @@ final class CliCryptoProSigner implements SignerInterface
         $this->tempDir = $tempDir ?? sys_get_temp_dir();
         $this->logger = new NullLogger();
 
-        if (!file_exists($this->tempDir)) {
+        if (!is_dir($this->tempDir)) {
             throw new NoSuchTmpDirException('Temporary folder is not found');
         }
         if (!is_writable($this->tempDir)) {
@@ -60,9 +60,13 @@ final class CliCryptoProSigner implements SignerInterface
         if ($messageFile === false) {
             throw new SignFailException('Cannot create a temporary file for signing');
         }
-        file_put_contents($messageFile, $message);
 
         try {
+            $bytes = file_put_contents($messageFile, $message);
+            if ($bytes === false || $bytes !== strlen($message)) {
+                throw new SignFailException('Cannot write the message to the temporary file');
+            }
+
             return $this->signFile($messageFile);
         } finally {
             if (file_exists($messageFile)) {
@@ -76,8 +80,10 @@ final class CliCryptoProSigner implements SignerInterface
      */
     private function signFile(string $messageFile): string
     {
+        // ESIA's client_secret must be a detached PKCS#7 signature; -base64
+        // makes cryptcp emit base64 text instead of the default binary DER.
         $command = escapeshellarg($this->toolPath)
-            . ' -signf -dir ' . escapeshellarg($this->tempDir)
+            . ' -signf -detached -base64 -dir ' . escapeshellarg($this->tempDir)
             . ' -cert -thumbprint ' . escapeshellarg($this->thumbprint);
         if ($this->pin !== null && $this->pin !== '') {
             $command .= ' -pin ' . escapeshellarg($this->pin);

--- a/src/Esia/Signer/CryptoProSigner.php
+++ b/src/Esia/Signer/CryptoProSigner.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Esia\Signer;
+
+use Esia\Signer\Exceptions\SignFailException;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
+
+/**
+ * Signs messages with CryptoPro CSP through the CryptoPro PHP extension
+ * (the `\CPStore` / `\CPSigner` / `\CPSignedData` COM-like classes).
+ *
+ * Runtime requirements:
+ *  - The proprietary CryptoPro PHP extension must be installed and enabled.
+ *  - A GOST R 34.10-2012 certificate with a private key must be present in the
+ *    current user's "My" store, referenced by its SHA-1 thumbprint.
+ *
+ * The extension is not available in this repository's test environment, so this
+ * signer is intentionally excluded from static analysis (see phpstan.neon).
+ *
+ * @see https://docs.cryptopro.ru/cades/plugin/plugin-methods
+ */
+final class CryptoProSigner implements SignerInterface
+{
+    use LoggerAwareTrait;
+    use UrlSafeSignatureTrait;
+
+    /**
+     * @param string $thumbprint SHA-1 thumbprint of the signing certificate
+     * @param string|null $pin PIN/password for the private key container, if any
+     */
+    public function __construct(
+        private string $thumbprint,
+        private ?string $pin = null
+    ) {
+        $this->logger = new NullLogger();
+    }
+
+    /**
+     * @throws SignFailException
+     */
+    public function sign(string $message): string
+    {
+        if (!class_exists(\CPStore::class)) {
+            throw new SignFailException('The CryptoPro PHP extension is not available');
+        }
+
+        $store = new \CPStore();
+        $store->Open(CURRENT_USER_STORE, 'My', STORE_OPEN_READ_ONLY);
+
+        $certificates = $store->get_Certificates();
+        $found = $certificates->Find(CERTIFICATE_FIND_SHA1_HASH, $this->thumbprint, 0);
+        $certificate = $found->Count() > 0 ? $found->Item(1) : null;
+        if ($certificate === null) {
+            throw new SignFailException('Cannot find the certificate by thumbprint');
+        }
+        if ($certificate->HasPrivateKey() === false) {
+            throw new SignFailException('The certificate has no associated private key');
+        }
+
+        $signer = new \CPSigner();
+        $signer->set_Certificate($certificate);
+        if ($this->pin !== null && $this->pin !== '') {
+            $signer->set_KeyPin($this->pin);
+        }
+
+        $signedData = new \CPSignedData();
+        $signedData->set_ContentEncoding(BASE64_TO_BINARY);
+        $signedData->set_Content(base64_encode($message));
+
+        $signature = $signedData->SignCades($signer, CADES_BES, true, ENCODE_BASE64);
+
+        return $this->normalizeBase64Signature($signature);
+    }
+}

--- a/src/Esia/Signer/UrlSafeSignatureTrait.php
+++ b/src/Esia/Signer/UrlSafeSignatureTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Esia\Signer;
+
+trait UrlSafeSignatureTrait
+{
+    /**
+     * Url safe for base64
+     */
+    protected function urlSafe(string $string): string
+    {
+        return rtrim(strtr(trim($string), '+/', '-_'), '=');
+    }
+
+    /**
+     * Normalize a base64 (possibly multi-line, PEM-wrapped) signature produced
+     * by an external tool into the url-safe base64 form ESIA expects.
+     */
+    protected function normalizeBase64Signature(string $signature): string
+    {
+        $signature = preg_replace('/-----(BEGIN|END)[^-]*-----/', '', $signature) ?? $signature;
+        $signature = str_replace(["\r", "\n", ' '], '', $signature);
+
+        return $this->urlSafe($signature);
+    }
+}

--- a/tests/unit/Signer/CliCryptoProSignerTest.php
+++ b/tests/unit/Signer/CliCryptoProSignerTest.php
@@ -66,20 +66,56 @@ class CliCryptoProSignerTest extends Unit
 
     public function testSign(): void
     {
-        $output = [];
-        $resultCode = 0;
-        exec('cryptcp -help 2>&1', $output, $resultCode);
-        if ($resultCode !== 0) {
-            $this->markTestSkipped('The cryptcp utility is not available');
+        $thumbprint = getenv('ESIA_CRYPTOPRO_THUMBPRINT');
+        if ($thumbprint === false || $thumbprint === '') {
+            $this->markTestSkipped(
+                'Set ESIA_CRYPTOPRO_THUMBPRINT (and optionally ESIA_CRYPTOPRO_CRYPTCP/'
+                . 'ESIA_CRYPTOPRO_PIN/ESIA_CRYPTOPRO_CACERT) to run the live cryptcp signing test'
+            );
         }
 
-        $signer = new CliCryptoProSigner(
-            'cryptcp',
-            '745187e5c161cd2e3130d886f9df4492fa270685',
-            'test'
-        );
+        $tool = getenv('ESIA_CRYPTOPRO_CRYPTCP') ?: 'cryptcp';
+        $pin = getenv('ESIA_CRYPTOPRO_PIN') ?: null;
 
-        $signature = $signer->sign('test');
+        $output = [];
+        $resultCode = 0;
+        exec(escapeshellarg($tool) . ' -help 2>&1', $output, $resultCode);
+        if ($resultCode !== 0) {
+            $this->markTestSkipped(sprintf('The %s utility is not available', $tool));
+        }
+
+        $message = 'esia-cryptopro-' . bin2hex(random_bytes(8));
+        $signer = new CliCryptoProSigner($tool, $thumbprint, $pin);
+
+        $signature = $signer->sign($message);
         self::assertNotEmpty($signature);
+
+        // The signer must return a url-safe base64 detached PKCS#7 signature.
+        $der = base64_decode(strtr($signature, '-_', '+/'), true);
+        self::assertNotFalse($der, 'Signature is not valid url-safe base64');
+
+        // When a CA certificate is provided, verify the detached signature
+        // round-trips through openssl, proving it covers the exact message.
+        $caCert = getenv('ESIA_CRYPTOPRO_CACERT');
+        if ($caCert !== false && $caCert !== '') {
+            $signaturePath = codecept_log_dir('cryptopro.der');
+            $messagePath = codecept_log_dir('cryptopro.msg');
+            file_put_contents($signaturePath, $der);
+            file_put_contents($messagePath, $message);
+
+            $command = 'openssl smime -verify -inform DER -noverify '
+                . '-in ' . escapeshellarg($signaturePath) . ' '
+                . '-content ' . escapeshellarg($messagePath) . ' '
+                . '-CAfile ' . escapeshellarg($caCert) . ' 2>&1';
+            $verifyOutput = [];
+            $verifyCode = 0;
+            exec($command, $verifyOutput, $verifyCode);
+
+            self::assertSame(
+                0,
+                $verifyCode,
+                'openssl verification failed: ' . implode("\n", $verifyOutput)
+            );
+        }
     }
 }

--- a/tests/unit/Signer/CliCryptoProSignerTest.php
+++ b/tests/unit/Signer/CliCryptoProSignerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\unit\Signer;
+
+use Codeception\Test\Unit;
+use Esia\Signer\CliCryptoProSigner;
+use Esia\Signer\Exceptions\NoSuchTmpDirException;
+use Esia\Signer\Exceptions\SignFailException;
+
+/**
+ * The `cryptcp` utility (CryptoPro CSP) is proprietary and unavailable in CI,
+ * so the actual signing test is skipped unless the tool is present. The
+ * constructor-validation tests run everywhere and give real coverage.
+ *
+ * @coversNothing
+ */
+class CliCryptoProSignerTest extends Unit
+{
+    public function testTempDirDoesNotExist(): void
+    {
+        $this->expectException(NoSuchTmpDirException::class);
+
+        new CliCryptoProSigner(
+            'cryptcp',
+            '745187e5c161cd2e3130d886f9df4492fa270685',
+            null,
+            '/no/such/directory/for/esia'
+        );
+    }
+
+    public function testTempDirIsNotWritable(): void
+    {
+        $readOnlyDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'esia_ro_' . bin2hex(random_bytes(4));
+        mkdir($readOnlyDir, 0500);
+
+        try {
+            if (is_writable($readOnlyDir)) {
+                $this->markTestSkipped('Cannot create a non-writable directory (running as root?)');
+            }
+
+            $this->expectException(NoSuchTmpDirException::class);
+
+            new CliCryptoProSigner(
+                'cryptcp',
+                '745187e5c161cd2e3130d886f9df4492fa270685',
+                null,
+                $readOnlyDir
+            );
+        } finally {
+            rmdir($readOnlyDir);
+        }
+    }
+
+    public function testSignFailsWhenToolIsMissing(): void
+    {
+        $signer = new CliCryptoProSigner(
+            '/nonexistent/cryptcp-binary',
+            '745187e5c161cd2e3130d886f9df4492fa270685'
+        );
+
+        $this->expectException(SignFailException::class);
+        $signer->sign('message');
+    }
+
+    public function testSign(): void
+    {
+        $output = [];
+        $resultCode = 0;
+        exec('cryptcp -help 2>&1', $output, $resultCode);
+        if ($resultCode !== 0) {
+            $this->markTestSkipped('The cryptcp utility is not available');
+        }
+
+        $signer = new CliCryptoProSigner(
+            'cryptcp',
+            '745187e5c161cd2e3130d886f9df4492fa270685',
+            'test'
+        );
+
+        $signature = $signer->sign('test');
+        self::assertNotEmpty($signature);
+    }
+}

--- a/tests/unit/Signer/CryptoProSignerTest.php
+++ b/tests/unit/Signer/CryptoProSignerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\unit\Signer;
+
+use Codeception\Test\Unit;
+use Esia\Signer\CryptoProSigner;
+use Esia\Signer\Exceptions\SignFailException;
+use Esia\Signer\SignerInterface;
+
+/**
+ * The CryptoPro PHP extension is proprietary and unavailable in CI, so the only
+ * behaviour we can assert here without it is the guard that throws a clear
+ * exception when the extension is missing.
+ *
+ * @coversNothing
+ */
+class CryptoProSignerTest extends Unit
+{
+    public function testIsSigner(): void
+    {
+        $signer = new CryptoProSigner('745187e5c161cd2e3130d886f9df4492fa270685');
+        self::assertInstanceOf(SignerInterface::class, $signer);
+    }
+
+    public function testSignFailsWithoutExtension(): void
+    {
+        if (class_exists(\CPStore::class)) {
+            $this->markTestSkipped('The CryptoPro PHP extension is installed');
+        }
+
+        $signer = new CryptoProSigner('745187e5c161cd2e3130d886f9df4492fa270685', 'pin');
+
+        $this->expectException(SignFailException::class);
+        $this->expectExceptionMessage('CryptoPro PHP extension is not available');
+        $signer->sign('message');
+    }
+}


### PR DESCRIPTION
Closes #69. Consolidates the closed PR #61 (Сигнеры для КриптоПро) into the current codebase.

## Problem
ESIA requires **GOST R 34.10-2012** signatures for the token request; RSA is gone in production. Until now only `CliSignerPKCS7` (OpenSSL built with the GOST engine) could sign for prod, leaving CryptoPro CSP users unsupported.

## Changes
Two new signers implementing `SignerInterface`, usable via `OpenId::setSigner()`:

- **`CliCryptoProSigner`** — signs through the CryptoPro `cryptcp` CLI, referencing a GOST certificate in the CSP store by SHA-1 thumbprint. Modernized from PR #61: `declare(strict_types=1)`, promoted typed properties, PSR-3 logger, **`escapeshellarg()`** on every argument (the original interpolated unescaped input), temp-dir validation, and url-safe base64 output.
- **`CryptoProSigner`** — signs through the proprietary CryptoPro PHP extension (`\CPStore`/`\CPSigner`/`\CPSignedData`), with a clear `SignFailException` guard when the extension isn't loaded.

Supporting changes:
- Extracted shared url-safe base64 handling into **`UrlSafeSignatureTrait`** (now also used by `AbstractSignerPKCS7`, replacing its private `urlSafe()`).
- `CryptoProSigner` is excluded from PHPStan (`phpstan.neon`) — the extension has no stubs and isn't installable in CI.
- **README**: new "Подпись запросов (сигнеры)" section with a comparison table (native / GOST-CLI / cryptcp / PHP-extension) and per-backend usage examples and runtime requirements.

## Tests
`tests/unit/Signer/CliCryptoProSignerTest.php` and `CryptoProSignerTest.php`:
- Constructor/temp-dir validation and the missing-tool / missing-extension guards run everywhere (real coverage without CryptoPro).
- The live `cryptcp` signing test skips when the utility is unavailable.

## Acceptance criteria (#69)
- [x] Working GOST/CryptoPro signer available via `setSigner()` (two backends)
- [x] Docs describe each signer's runtime requirements
- [x] Round-trip / signing test (skips gracefully without the proprietary tooling; existing GOST round-trip via `CliSignerRoundTripTest` still covers the OpenSSL-engine path)

Verified locally: phpstan OK, php-cs-fixer clean, composer normalize clean, unit suite green (except the known GOST-CLI test that only passes with the GOST OpenSSL engine in CI).