### PR TITLE
feat: inject signer & logger via constructor (#76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,23 @@ $esia->setSigner(new \Esia\Signer\CryptoProSigner(
 
 Все сигнеры поддерживают PSR-3 логгер через `setLogger()`.
 
+Сигнер и логгер также можно передать сразу в конструктор `\Esia\OpenId`
+(удобно для DI-контейнеров), не прибегая к сеттерам:
+
+```php
+$esia = new \Esia\OpenId(
+    $config,
+    $httpClient,      // ?Psr\Http\Client\ClientInterface
+    $requestFactory,  // ?Psr\Http\Message\RequestFactoryInterface
+    $streamFactory,   // ?Psr\Http\Message\StreamFactoryInterface
+    $signer,          // ?Esia\Signer\SignerInterface
+    $logger           // ?Psr\Log\LoggerInterface
+);
+```
+
+Любой из аргументов можно передать как `null` — тогда используется значение по
+умолчанию. Методы `setSigner()` и `setLogger()` продолжают работать.
+
 
 
 Токен - jwt токен которые вы получаете от ЕСИА для дальнейшего взаимодействия

--- a/src/Esia/OpenId.php
+++ b/src/Esia/OpenId.php
@@ -25,6 +25,7 @@ use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use RuntimeException;
 
@@ -61,19 +62,28 @@ class OpenId
         Config $config,
         ?ClientInterface $client = null,
         ?RequestFactoryInterface $requestFactory = null,
-        ?StreamFactoryInterface $streamFactory = null
+        ?StreamFactoryInterface $streamFactory = null,
+        ?SignerInterface $signer = null,
+        ?LoggerInterface $logger = null
     ) {
         $this->config = $config;
         $this->client = $client ?? Psr18ClientDiscovery::find();
         $this->requestFactory = $requestFactory ?? Psr17FactoryDiscovery::findRequestFactory();
         $this->streamFactory = $streamFactory ?? Psr17FactoryDiscovery::findStreamFactory();
-        $this->logger = new NullLogger();
-        $this->signer = new SignerPKCS7(
-            $config->getCertPath(),
-            $config->getPrivateKeyPath(),
-            $config->getPrivateKeyPassword(),
-            $config->getTmpPath()
-        );
+        $this->logger = $logger ?? new NullLogger();
+
+        if ($signer !== null) {
+            $this->signer = $signer;
+        } else {
+            $defaultSigner = new SignerPKCS7(
+                $config->getCertPath(),
+                $config->getPrivateKeyPath(),
+                $config->getPrivateKeyPassword(),
+                $config->getTmpPath()
+            );
+            $defaultSigner->setLogger($this->logger);
+            $this->signer = $defaultSigner;
+        }
 
         $esiaCertPath = $config->getEsiaCertPath();
         if ($esiaCertPath !== null && $esiaCertPath !== '') {

--- a/tests/unit/OpenIdTest.php
+++ b/tests/unit/OpenIdTest.php
@@ -8,10 +8,12 @@ use Esia\Exceptions\AbstractEsiaException;
 use Esia\Exceptions\InvalidConfigurationException;
 use Esia\OpenId;
 use Esia\Signer\Exceptions\SignFailException;
+use Esia\Signer\SignerInterface;
 use Http\Mock\Client as MockClient;
 use Nyholm\Psr7\Response;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Log\AbstractLogger;
 
 class OpenIdTest extends Unit
 {
@@ -320,6 +322,90 @@ class OpenIdTest extends Unit
 
         $openId->getToken('test');
         self::assertSame($injectedState, $config->getState());
+    }
+
+    /**
+     * The signer passed to the constructor must be used instead of the default
+     * one (DI, see #76).
+     *
+     * @throws InvalidConfigurationException
+     * @throws SignFailException
+     */
+    public function testConstructorInjectsSigner(): void
+    {
+        $config = new Config($this->config);
+
+        $signer = new class () implements SignerInterface {
+            public bool $called = false;
+
+            public function sign(string $message): string
+            {
+                $this->called = true;
+
+                return 'injected-signature';
+            }
+        };
+
+        $openId = new OpenId($config, null, null, null, $signer);
+        $url = $openId->buildUrl();
+
+        self::assertTrue($signer->called);
+        self::assertStringContainsString('client_secret=injected-signature', $url);
+    }
+
+    /**
+     * The logger passed to the constructor must be used (DI, see #76).
+     *
+     * @throws InvalidConfigurationException
+     * @throws AbstractEsiaException
+     */
+    public function testConstructorInjectsLogger(): void
+    {
+        $config = new Config($this->config);
+
+        $logger = new class () extends AbstractLogger {
+            /** @var array<int, string> */
+            public array $messages = [];
+
+            public function log($level, $message, array $context = []): void
+            {
+                $this->messages[] = (string) $message;
+            }
+        };
+
+        $oid = '123';
+        $oidBase64 = base64_encode('{ "urn:esia:sbj_id" : ' . $oid . '}');
+        $client = $this->buildClientWithResponses([
+            new Response(200, [], '{ "access_token": "test.' . $oidBase64 . '.test"}'),
+        ]);
+        $openId = new OpenId($config, $client, null, null, null, $logger);
+
+        $openId->getToken('test');
+        self::assertNotEmpty($logger->messages);
+    }
+
+    /**
+     * Existing setter-based configuration must keep working (no BC break).
+     *
+     * @throws InvalidConfigurationException
+     * @throws SignFailException
+     */
+    public function testSetSignerStillWorks(): void
+    {
+        $config = new Config($this->config);
+
+        $signer = new class () implements SignerInterface {
+            public function sign(string $message): string
+            {
+                return 'setter-signature';
+            }
+        };
+
+        $openId = new OpenId($config);
+        $openId->setSigner($signer);
+        $url = $openId->buildUrl();
+
+        self::assertStringContainsString('client_secret=setter-signature', $url);
     }
 
     /**


### PR DESCRIPTION
## Что
Расширяет конструктор `\Esia\OpenId` необязательными аргументами:
- `?\Esia\Signer\SignerInterface $signer` (5-й параметр)
- `?\Psr\Log\LoggerInterface $logger` (6-й параметр)

## Зачем
Позволяет внедрять сигнер и логгер через конструктор (DI-контейнеры), не прибегая к сеттерам. Реализует #76 и консолидирует закрытый PR #39.

## Обратная совместимость
- Новые параметры имеют значение `null` по умолчанию — поведение не меняется.
- При `null`-логгере он передаётся в дефолтный `SignerPKCS7`.
- `setSigner()` / `setLogger()` продолжают работать.

## Тесты
- инъекция сигнера через конструктор используется при подписи;
- инъекция логгера через конструктор получает записи;
- сеттер `setSigner()` по-прежнему работает.

Closes #76