### PR TITLE
fix(signer): убрать лишний -detached у cryptcp -signf

### DIFF
--- a/src/Esia/Signer/CliCryptoProSigner.php
+++ b/src/Esia/Signer/CliCryptoProSigner.php
@@ -80,10 +80,12 @@ final class CliCryptoProSigner implements SignerInterface
      */
     private function signFile(string $messageFile): string
     {
-        // ESIA's client_secret must be a detached PKCS#7 signature; -base64
-        // makes cryptcp emit base64 text instead of the default binary DER.
+        // ESIA's client_secret must be a detached PKCS#7 signature. `cryptcp
+        // -signf` already produces a detached signature (a separate `.sgn`
+        // file), so no extra flag is needed. `-base64` makes cryptcp emit
+        // base64 text instead of the default binary DER.
         $command = escapeshellarg($this->toolPath)
-            . ' -signf -detached -base64 -dir ' . escapeshellarg($this->tempDir)
+            . ' -signf -base64 -dir ' . escapeshellarg($this->tempDir)
             . ' -cert -thumbprint ' . escapeshellarg($this->thumbprint);
         if ($this->pin !== null && $this->pin !== '') {
             $command .= ' -pin ' . escapeshellarg($this->pin);


### PR DESCRIPTION
## Что и почему

В #89 бот Copilot ошибочно указал, что `cryptcp -signf` создаёт **прикреплённую** подпись, и предложил добавить `-detached`. Это было применено (`2c0406e`).

@ilimurzin [справедливо заметил](https://github.com/fr05t1k/esia/pull/89#discussion_r3751649768), что **`cryptcp -signf` уже создаёт открепленную (detached) подпись** — отдельный файл `.sgn`; параметра `-detached` в документации для `-signf` нет.

Это подтверждается и нашим кодом: мы читаем отдельный `$messageFile.'.sgn'` и возвращаем его как `client_secret` — что и есть detached-подпись.

## Изменение

Убран флаг `-detached` из вызова `cryptcp -signf` (оставлены `-signf -base64`). Поведение — detached PKCS#7 — не меняется; убран лишний флаг, который на части версий cryptcp мог бы вызвать ошибку неизвестного параметра. Комментарий уточнён.

## Проверка

- Unit-тесты `CliCryptoProSignerTest` зелёные (реальный тест подписи пропускается без cryptcp, как и в CI).
- Прямая проверка на реальном cryptcp не выполнялась — у авторов нет доступа к CryptoPro CSP (проприетарное ПО, загрузка за регистрацией). Исправление основано на замечании ревьюера и документированном поведении `-signf`.

Closes review thread in #89.